### PR TITLE
Use CONNMARK for connection handling

### DIFF
--- a/root/usr/share/xray/firewall_include.lua
+++ b/root/usr/share/xray/firewall_include.lua
@@ -30,10 +30,12 @@ local rules = [[-A OUTPUT -j TP_SPEC_WAN_DG
 -A TP_SPEC_WAN_DG -m set --match-set tp_spec_dst_bp dst -j RETURN
 -A TP_SPEC_WAN_DG -m set --match-set tp_spec_def_gw dst -j RETURN
 -A TP_SPEC_WAN_DG -m mark --mark 0x%x -j RETURN
--A TP_SPEC_WAN_DG -p tcp -j MARK --set-xmark 0xfc/0xffffffff
--A TP_SPEC_WAN_DG -p udp -j MARK --set-xmark 0xfc/0xffffffff
+-A TP_SPEC_WAN_DG -p tcp -m mark --mark 0xfb/0xffffffff -j CONNMARK --restore-mark
+-A TP_SPEC_WAN_DG -p udp -m mark --mark 0xfb/0xffffffff -j CONNMARK --restore-mark
 -A TP_SPEC_WAN_FW -p tcp -j TPROXY --on-port %d --on-ip 0.0.0.0 --tproxy-mark 0xfb/0xffffffff
 -A TP_SPEC_WAN_FW -p udp -j TPROXY --on-port %d --on-ip 0.0.0.0 --tproxy-mark 0xfb/0xffffffff
+-A TP_SPEC_WAN_FW -p tcp -m mark --mark 0xfb/0xffffffff -j CONNMARK --save-mark
+-A TP_SPEC_WAN_FW -p udp -m mark --mark 0xfb/0xffffffff -j CONNMARK --save-mark
 COMMIT
 *filter
 COMMIT


### PR DESCRIPTION
This PR fixes #50. Meanwhile, the purposed change **introduced a new dependency** `iptables-mod-conntrack-extra` which should be added before merge.

I have to say that I'm still a bit confused about the internals of these functions. But for me it works.

![image](https://user-images.githubusercontent.com/2762704/118828104-8d2a8280-b8ef-11eb-936d-49da82bb91b7.png)


References:
- [istio/istio#23369 (comment)](https://github.com/istio/istio/issues/23369#issuecomment-717955075)
- [How to use TPROXY with 2 lan interfaces and one wan](https://netfilter.vger.kernel.narkive.com/U5GbstYZ/how-to-use-tproxy-with-2-lan-interfaces-and-one-wan)
- [iproute - What's the meaning of these ip route rules - Unix & Linux Stack Exchange](https://unix.stackexchange.com/questions/626779/whats-the-meaning-of-these-ip-route-rules)
- [mmproxy - Creative Linux routing to preserve client IP addresses in L7 proxies](https://blog.cloudflare.com/mmproxy-creative-way-of-preserving-client-ips-in-spectrum/)
- THE manual: [Man page of iptables-extensions](https://ipset.netfilter.org/iptables-extensions.man.html)